### PR TITLE
Updated branding on connection & spectator screen.

### DIFF
--- a/ratoa_gamecode/code/cgame/cg_draw.c
+++ b/ratoa_gamecode/code/cgame/cg_draw.c
@@ -5750,7 +5750,7 @@ static void CG_DrawSpectator(void) {
 	}
 	CG_DrawTinyScoreString(320 - (CG_DrawStrlen(s)*SCORETINYCHAR_WIDTH)/2, 458, s, 1.0F);
 	s = "Help: " S_COLOR_GREEN "\\help" S_COLOR_WHITE " or " S_COLOR_GREEN "\\doc" S_COLOR_WHITE " or visit "
-	       	S_COLOR_CYAN "https://ratmod.github.io";
+	       	S_COLOR_CYAN "https://devoq3.net/";
 	CG_DrawTinyScoreString(320 - (CG_DrawStrlen(s)*SCORETINYCHAR_WIDTH)/2, 468, s, 1.0F);
 }
 

--- a/ratoa_gamecode/code/cgame/cg_info.c
+++ b/ratoa_gamecode/code/cgame/cg_info.c
@@ -178,11 +178,10 @@ void CG_DrawInformation( void ) {
 	color[3] = 0.6;
 	CG_FillRect( 0, 450, 640, 40, color);
 			
-	CG_DrawScoreString(10, 465-SCORECHAR_HEIGHT/2, S_COLOR_YELLOW "RAT" S_COLOR_BLACK "mod"
-			"   ---<(((" S_COLOR_YELLOW ":" S_COLOR_BLACK ">", 1.0, 0);
-	s = S_COLOR_YELLOW "By the rats, for the rats";
+	CG_DrawScoreString(10, 465-SCORECHAR_HEIGHT/2, S_COLOR_YELLOW "DEVOTION" S_COLOR_BLACK "mod", 1.0, 0);
+	s = S_COLOR_YELLOW "A pristine, unlagged experience for Quake III Arena.";
 	CG_DrawTinyScoreString(635-CG_DrawStrlen(s)*SCORETINYCHAR_WIDTH, 465-1-SCORETINYCHAR_HEIGHT, s, 1.0);
-	s = S_COLOR_CYAN "https://ratmod.github.io";
+	s = S_COLOR_CYAN "https://devoq3.net/";
 	CG_DrawTinyScoreString(635-CG_DrawStrlen(s)*SCORETINYCHAR_WIDTH, 465+1, s, 1.0);
 
 	// the first 150 rows are reserved for the client connection


### PR DESCRIPTION
Hello,
I noticed the Spectator screen and Connection screen still referenced ratmod URLs instead of the new devotion URL. This PR updates the links and the mod name. 

![shot-20230313-202313](https://user-images.githubusercontent.com/32006541/224886664-337fbe12-ceaf-464b-b8a4-c5d73088f3a1.jpg)
![shot-20230313-202319](https://user-images.githubusercontent.com/32006541/224886668-66f95bb1-b46f-47f9-af1e-978e72b66a8b.jpg)

No other changes. 
