### PR TITLE
Correct gameNames to reflect supported gametype (Closes #38)

### DIFF
--- a/ratoa_gamecode/code/game/g_cmds.c
+++ b/ratoa_gamecode/code/game/g_cmds.c
@@ -3721,14 +3721,14 @@ static const char *gameNames[] = {
 	"Single Player",
 	"Team Deathmatch",
 	"Capture the Flag",
-	"One Flag CTF",
-	"Overload",
-	"Harvester",
-	"Elimination",
-	"CTF Elimination",
-	"Last Man Standing",
-	"Double Domination",
-	"Domination"
+	"Elimination",        //"One Flag CTF",
+	"CTF Elimination",    //"Overload",
+	"Last Man Standing",  //"Harvester",
+	"Multi Tournament",   //"Elimination",
+	//"CTF Elimination",
+	//"Last Man Standing",
+	//"Double Domination",
+	//"Domination"
 };
 
 


### PR DESCRIPTION
When a player performs "/callvote g_gametype 5" (or a higher number), an incorrect gametype is displayed in the console text, adding confusion. The root of this issue is that char *gamenames[] does not list the  gametypes in the appropriate order. This PR resolves that by correcting the text in the array to match the actual game types offered. 

The end result is that the console text matches the game type being under call vote. 

Broken:
![broken](https://user-images.githubusercontent.com/32006541/233191395-1b16d705-fd2b-4cde-81de-ae34cbe1c704.png)

Fixed:
![fix](https://user-images.githubusercontent.com/32006541/233190640-c730ab45-ee60-4f6d-8179-3c3717fec8e2.png)
